### PR TITLE
Increase answer object text sizes

### DIFF
--- a/src/core/GameScene.ts
+++ b/src/core/GameScene.ts
@@ -1484,7 +1484,7 @@ export class GameScene extends Phaser.Scene {
             // Add label if needed
 
             const lbl = this.add.text(x, y, answer.toString(), {
-                font: `${Math.floor(32 * scaleFactor)}px Arial`, color: this.optionLabelColor, fontStyle: 'bold', stroke: this.optionLabelStroke, strokeThickness: Math.floor(5 * scaleFactor)
+                font: `${Math.floor(48 * scaleFactor)}px Arial`, color: this.optionLabelColor, fontStyle: 'bold', stroke: this.optionLabelStroke, strokeThickness: Math.floor(5 * scaleFactor)
             }).setOrigin(0.5).setDepth(depth + 100);
             obj.setData('label', lbl);
             this.answerObjectLabels.push(lbl);


### PR DESCRIPTION
## Summary

Made text on answer objects 50% bigger

## Changes

- Increased answer object text sizes by 50% by modifying font size from 32 * scaleFactor to 48 * scaleFactor

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

Describe the tests you ran to verify your changes:

- [x] `npm run test` passes
- [x] `npm run type-check` passes
- [x] `npm run build` succeeds
- [x] Manual testing performed (describe below)

### Manual Testing Steps

1. Ran `npm run dev` and visually confirmed that text size of answer objects increased

## Checklist

- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
